### PR TITLE
Canvas is now in overlay mode and also has sorting layer of 2

### DIFF
--- a/BlockBlock/Assets/Scenes/Game.unity
+++ b/BlockBlock/Assets/Scenes/Game.unity
@@ -406,7 +406,7 @@ Canvas:
   m_GameObject: {fileID: 1239106970}
   m_Enabled: 1
   serializedVersion: 3
-  m_RenderMode: 1
+  m_RenderMode: 0
   m_Camera: {fileID: 519420031}
   m_PlaneDistance: 100
   m_PixelPerfect: 0
@@ -416,7 +416,7 @@ Canvas:
   m_SortingBucketNormalizedSize: 0
   m_AdditionalShaderChannelsFlag: 0
   m_SortingLayerID: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 2
   m_TargetDisplay: 0
 --- !u!224 &1239106974
 RectTransform:


### PR DESCRIPTION
block pieces currently only go up to sorting layer of 1, so with a sorting layer of 2, the canvas UI elements will always appear above the blocks